### PR TITLE
fix: rewrite consumption logic

### DIFF
--- a/encoder/message_handler.py
+++ b/encoder/message_handler.py
@@ -5,10 +5,10 @@ After parsing metadata from the message, prep and send commands.
 
 import asyncio
 import json
+from dataclasses import dataclass
 
 from aio_pika import IncomingMessage
-from aio_pika.abc import AbstractChannel, AbstractRobustExchange
-from aio_pika.exceptions import AMQPError
+from aio_pika.abc import AbstractRobustExchange
 from smartgen import SmartGenConnectionManager
 from utils.logging import configure_logging
 from utils.rt_plus import build_rt_plus_tag_command
@@ -17,31 +17,248 @@ from utils.sanitization import sanitize_text
 logger = configure_logging(__name__)
 
 
-async def parse_payload(raw_payload: str) -> tuple[str, str, int]:
+@dataclass
+class TrackInfo:
+    """Holds parsed track information."""
+
+    artist: str
+    title: str
+    duration_seconds: int
+
+
+class MessageProcessor:
+    """Processes RabbitMQ messages and sends to SmartGen encoder.
+
+    Only keeps the latest track info - stale messages are dropped since
+    RDS only cares about what's currently playing.
+    """
+
+    def __init__(self, smartgen_mgr: SmartGenConnectionManager):
+        self.smartgen_mgr = smartgen_mgr
+        self._latest_track: TrackInfo | None = None
+        self._lock = asyncio.Lock()
+        self._processor_task: asyncio.Task | None = None
+        self._new_track_event = asyncio.Event()
+        self._stop = False
+
+    async def start(self):
+        """Start the background processor task."""
+        self._processor_task = asyncio.create_task(self._process_loop())
+
+    async def stop(self):
+        """Stop the background processor task."""
+        self._stop = True
+        self._new_track_event.set()  # Wake up the loop
+        if self._processor_task:
+            self._processor_task.cancel()
+            try:
+                await self._processor_task
+            except asyncio.CancelledError:
+                pass
+
+    async def handle_message(
+        self,
+        message: IncomingMessage,
+        _preview_exchange: AbstractRobustExchange | None,
+    ) -> None:
+        """Handle an incoming message from RabbitMQ.
+
+        Acks the message immediately and stores track info for processing.
+
+        Only the latest track is kept - older tracks are discarded.
+
+        Args:
+            message: The incoming RabbitMQ message.
+            _preview_exchange: The preview exchange (currently unused).
+        """
+        # Always ack immediately to prevent queue buildup
+        try:
+            await message.ack()
+        except Exception as e:
+            logger.warning("Failed to ack message: %s", e)
+            return
+
+        # Parse the message
+        try:
+            raw_payload = message.body.decode("utf-8")
+            logger.debug("Received payload: `%s`", raw_payload)
+            track_info = await _parse_payload(raw_payload)
+        except json.JSONDecodeError:
+            logger.critical("Failed to parse JSON from payload: `%s`", raw_payload)
+            return
+        except ValueError as e:
+            logger.critical("Invalid payload: `%s`", e)
+            return
+
+        # Store as latest track (replacing any previous)
+        async with self._lock:
+            old_track = self._latest_track
+            self._latest_track = track_info
+
+            if old_track is not None:
+                logger.debug(
+                    "Replacing stale track `%s` - `%s` with `%s` - `%s`",
+                    old_track.artist,
+                    old_track.title,
+                    track_info.artist,
+                    track_info.title,
+                )
+
+        logger.info(
+            "Queued for processing: `%s` - `%s`",
+            track_info.artist,
+            track_info.title,
+        )
+
+        # Signal the processor that there's a new track
+        self._new_track_event.set()
+
+    async def _process_loop(self):
+        """Background loop that processes the latest track when SmartGen is available."""
+        while not self._stop:
+            # Wait for a new track or periodic check
+            try:
+                await asyncio.wait_for(self._new_track_event.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                pass  # Periodic check even without new track
+
+            self._new_track_event.clear()
+
+            if self._stop:
+                break
+
+            # Get the latest track
+            async with self._lock:
+                track = self._latest_track
+                if track is None:
+                    continue
+
+            # Wait for SmartGen connection
+            if not self.smartgen_mgr.is_connected:
+                logger.info(
+                    "Waiting for SmartGen connection before processing: `%s` - `%s`",
+                    track.artist,
+                    track.title,
+                )
+                connected = await self.smartgen_mgr.wait_for_connection(timeout=30.0)
+                if not connected:
+                    # Check if there's a newer track now
+                    async with self._lock:
+                        if self._latest_track is not track:
+                            logger.info(
+                                "Discarding stale track `%s` - `%s` (newer track available)",
+                                track.artist,
+                                track.title,
+                            )
+                            continue
+                    # No newer track, keep waiting
+                    logger.warning(
+                        "SmartGen connection timeout, will retry: `%s` - `%s`",
+                        track.artist,
+                        track.title,
+                    )
+                    continue
+
+            # Re-check that this is still the latest track before processing
+            async with self._lock:
+                if self._latest_track is not track:
+                    logger.info(
+                        "Discarding stale track `%s` - `%s` (newer track available)",
+                        track.artist,
+                        track.title,
+                    )
+                    continue
+                # Clear so we don't reprocess
+                self._latest_track = None
+
+            # Process the track
+            await self._process_track(track)
+
+    async def _process_track(self, track: TrackInfo) -> None:
+        """Process a single track and send to encoder.
+
+        Args:
+            track: The track information to process.
+        """
+        try:
+            # Sanitize metadata
+            sanitized_artist, sanitized_title = await _sanitize_metadata(
+                track.artist, track.title
+            )
+            logger.debug(
+                "Sanitized track info: `%s` - `%s`",
+                sanitized_artist,
+                sanitized_title,
+            )
+
+            # Create TEXT field
+            truncated_text, truncated = _create_text_field(
+                sanitized_artist, sanitized_title
+            )
+
+            if truncated:
+                logger.warning("TEXT value truncated to 64 chars: `%s`", truncated_text)
+
+            # Determine RT+ tags
+            rt_plus_artist, rt_plus_title = _determine_rt_plus_tags(
+                sanitized_artist, sanitized_title, truncated_text
+            )
+
+            # Send to encoder
+            await _send_to_encoder(
+                self.smartgen_mgr,
+                truncated_text,
+                rt_plus_artist,
+                rt_plus_title,
+                track.duration_seconds,
+            )
+
+            logger.info(
+                "Successfully sent to encoder: `%s` - `%s`",
+                sanitized_artist,
+                sanitized_title,
+            )
+
+        except (ConnectionError, OSError, asyncio.TimeoutError) as e:
+            logger.error("Failed to send to encoder: %s", e)
+            # Re-queue this track for retry
+            async with self._lock:
+                if self._latest_track is None:
+                    self._latest_track = track
+                    logger.info(
+                        "Re-queued track for retry: `%s` - `%s`",
+                        track.artist,
+                        track.title,
+                    )
+        except RuntimeError as e:
+            logger.error("Processing error (will not retry): %s", e)
+
+
+async def _parse_payload(raw_payload: str) -> TrackInfo:
     """Parse JSON payload and extract artist, title, duration.
 
     Args:
         raw_payload: The raw JSON payload string.
 
     Returns:
-        A tuple containing the artist, title, and duration in seconds.
+        A `TrackInfo` object containing the artist, title, and duration.
 
     Raises:
         ValueError: If artist or title is missing from the payload.
         json.JSONDecodeError: If the payload is not valid JSON.
     """
-    track_info = json.loads(raw_payload)
-    artist = track_info.get("artist")
-    title = track_info.get("song")
-    duration_seconds = track_info.get("duration", 0)
+    track_data = json.loads(raw_payload)
+    artist = track_data.get("artist")
+    title = track_data.get("song")
+    duration_seconds = track_data.get("duration", 0)
 
     if not artist or not title:
         raise ValueError("Missing track info in payload")
 
-    return artist, title, duration_seconds
+    return TrackInfo(artist=artist, title=title, duration_seconds=duration_seconds)
 
 
-async def sanitize_metadata(artist: str, title: str) -> tuple[str, str]:
+async def _sanitize_metadata(artist: str, title: str) -> tuple[str, str]:
     """Sanitize metadata fields.
 
     Args:
@@ -56,7 +273,7 @@ async def sanitize_metadata(artist: str, title: str) -> tuple[str, str]:
     return sanitized_artist, sanitized_title
 
 
-def create_text_field(artist: str, title: str) -> tuple[str, bool]:
+def _create_text_field(artist: str, title: str) -> tuple[str, bool]:
     """Create and possibly truncate the `TEXT` field.
 
     Args:
@@ -73,7 +290,7 @@ def create_text_field(artist: str, title: str) -> tuple[str, bool]:
     return truncated_text, truncated
 
 
-def find_fitting_prefix(
+def _find_fitting_prefix(
     field: str, text: str, max_len: int, ellipsis: str = "..."
 ) -> str:
     """Find the longest prefix of a field that fits within truncated text.
@@ -98,7 +315,7 @@ def find_fitting_prefix(
     return ""
 
 
-def determine_rt_plus_tags(
+def _determine_rt_plus_tags(
     artist: str, title: str, truncated_text: str
 ) -> tuple[str, str]:
     """Determine RT+ tags based on what's included in the truncated text.
@@ -108,23 +325,6 @@ def determine_rt_plus_tags(
     is present in the text, appending `'...'` if truncated.
 
     Ensures the final text remains within 64 characters total.
-
-    Example:
-        If everything fits::
-
-            artist = "Artist Name"
-            title = "Song Title"
-            truncated_text = "Artist Name - Song Title"
-            rt_plus_artist = "Artist Name"
-            rt_plus_title = "Song Title"
-
-        If truncation occurs::
-
-            artist = "Very Long Artist Name"
-            title = "Long Song Title"
-            truncated_text = "Very Long Artist Name - Long So..."
-            rt_plus_artist = "Very Long Artist Name"
-            rt_plus_title = "Long So..."
 
     Args:
         artist: The artist name.
@@ -136,24 +336,22 @@ def determine_rt_plus_tags(
     """
     ellipsis = "..."
 
-    # 3 is subtracted to account for the space and dash between artist
-    # and title (` - `)
     if artist in truncated_text:
         rt_plus_artist = artist
     else:
         max_artist_len = max(0, 64 - len(title) - len(ellipsis) - 3)
-        rt_plus_artist = find_fitting_prefix(artist, truncated_text, max_artist_len)
+        rt_plus_artist = _find_fitting_prefix(artist, truncated_text, max_artist_len)
 
     if title in truncated_text:
         rt_plus_title = title
     else:
         max_title_len = max(0, 64 - len(rt_plus_artist) - len(ellipsis) - 3)
-        rt_plus_title = find_fitting_prefix(title, truncated_text, max_title_len)
+        rt_plus_title = _find_fitting_prefix(title, truncated_text, max_title_len)
 
     return rt_plus_artist, rt_plus_title
 
 
-async def send_to_encoder(
+async def _send_to_encoder(
     smartgen_mgr: SmartGenConnectionManager,
     truncated_text: str,
     rt_plus_artist: str,
@@ -187,99 +385,36 @@ async def send_to_encoder(
     await smartgen_mgr.send_command("RT+TAG", rt_plus_payload, truncated_text)
 
 
+# Module-level processor instance (lazily initialized on first message)
+_processor: MessageProcessor | None = None
+
+
 async def on_message(
     message: IncomingMessage,
     smartgen_mgr: SmartGenConnectionManager,
-    _preview_exchange: AbstractRobustExchange | None,
+    preview_exchange: AbstractRobustExchange | None,
 ) -> None:
-    """Handle incoming messages from RabbitMQ.
+    """Handle incoming message from RabbitMQ consumer.
 
-    Extracts track metadata and sends commands to the SmartGen encoder.
-
-    On recoverable errors (e.g., network failures or encoder connection
-    problems), the message is re-queued. Non-recoverable errors (e.g.,
-    JSON errors, missing payload fields) are logged but not re-queued.
+    Creates the MessageProcessor on first call and reuses it for all
+    subsequent messages.
 
     Args:
         message: The incoming RabbitMQ message.
         smartgen_mgr: The SmartGen connection manager.
-        _preview_exchange: The preview exchange (currently unused).
+        preview_exchange: The preview exchange (currently unused).
     """
-    async with message.process():
-        raw_payload = None
-        try:
-            raw_payload = message.body.decode("utf-8")
-            logger.debug("Received payload: `%s`", raw_payload)
+    global _processor  # noqa: PLW0603
+    if _processor is None:
+        _processor = MessageProcessor(smartgen_mgr)
+        await _processor.start()
 
-            artist, title, duration_seconds = await parse_payload(raw_payload)
-            logger.debug("Extracted track info: `%s` - `%s`", artist, title)
+    await _processor.handle_message(message, preview_exchange)
 
-            # (1) Wait for SmartGen connection before processing. This avoids
-            #   repeated sanitization/unidecode logs when encoder is unavailable.
-            if not smartgen_mgr.is_connected:
-                logger.info(
-                    "Waiting for SmartGen connection before processing: `%s` - `%s`",
-                    artist,
-                    title,
-                )
-                connected = await smartgen_mgr.wait_for_connection(timeout=30.0)
-                if not connected:
-                    raise ConnectionError(
-                        "SmartGen connection timeout - encoder unavailable"
-                    )
 
-            # (2) Sanitize (unidecode, filter profanity, truncate, uppercase)
-            sanitized_artist, sanitized_title = await sanitize_metadata(artist, title)
-            logger.debug(
-                "Returned sanitized track info: `%s` - `%s`",
-                sanitized_artist,
-                sanitized_title,
-            )
-
-            # (3) Create a TEXT value
-            truncated_text, truncated = create_text_field(
-                sanitized_artist, sanitized_title
-            )
-
-            if truncated:
-                logger.warning("TEXT value truncated to 64 chars: `%s`", truncated_text)
-
-            # (4) Determine RT+ tagging
-            rt_plus_artist, rt_plus_title = determine_rt_plus_tags(
-                sanitized_artist, sanitized_title, truncated_text
-            )
-
-            # (5) Send commands to SmartGen Encoder. At this point, we
-            #   know that the track info is sanitized (unidecode) safe
-            #   to broadcast (profanity filtered), and truncated to fit
-            #   within the SmartGen `TEXT=` character limit.
-            await send_to_encoder(
-                smartgen_mgr,
-                truncated_text,
-                rt_plus_artist,
-                rt_plus_title,
-                duration_seconds,
-            )
-
-            # TODO: publish to the preview queue
-
-        except json.JSONDecodeError:
-            logger.critical("Failed to parse JSON from payload: `%s`", raw_payload)
-        except (ValueError, RuntimeError) as e:
-            logger.critical("Invalid payload or processing error: `%s`", e)
-        except (
-            ConnectionError,
-            OSError,
-            asyncio.TimeoutError,
-            AMQPError,
-        ) as e:
-            logger.exception("Communication error: `%s`", e)
-            try:
-                if not message.channel.is_closed:
-                    await message.nack(requeue=True)
-                else:
-                    logger.warning(
-                        "Channel closed, cannot nack message (will be redelivered)"
-                    )
-            except Exception as nack_err:
-                logger.warning("Failed to nack message: `%s`", nack_err)
+async def shutdown_processor() -> None:
+    """Shutdown the message processor if running."""
+    global _processor  # noqa: PLW0603
+    if _processor is not None:
+        await _processor.stop()
+        _processor = None

--- a/encoder/rds.py
+++ b/encoder/rds.py
@@ -11,6 +11,7 @@ import signal
 import sys
 
 from config import RABBITMQ_HOST, RDS_ENCODER_HOST, RDS_ENCODER_PORT
+from message_handler import shutdown_processor
 from rabbitmq_consumer import consume_rabbitmq
 from smartgen import SmartGenConnectionManager
 from utils.logging import configure_logging
@@ -49,6 +50,7 @@ async def main():
     connection = await consume_rabbitmq(smartgen_mgr, shutdown_event)
 
     logger.info("Shutting down gracefully...")
+    await shutdown_processor()
     await smartgen_mgr.stop()
     # Ensure connection is not None before attempting to close,
     # as consume_rabbitmq might return None if shutdown occurs during its setup.


### PR DESCRIPTION
- Fix double message ack/nack bug that caused MessageProcessError: Message already processed errors
- Implement "latest track only" logic - drop stale messages when SmartGen is unavailable since RDS only cares about what's currently playing
- Messages are now acked immediately to prevent RabbitMQ queue buildup during encoder outages